### PR TITLE
Detect escaped quotation marks in readQuotedString

### DIFF
--- a/lib/src/imap_buffer.dart
+++ b/lib/src/imap_buffer.dart
@@ -13,20 +13,20 @@ class ImapBuffer {
 
   /// Contains all chars that have special token types
   static const Map<int, ImapWordType> _specialChars = const <int, ImapWordType>{
-    10: ImapWordType.eol, // "\n"
-    43: ImapWordType.tokenPlus, // "+"
-    42: ImapWordType.tokenAsterisk, // "*"
-    40: ImapWordType.parenOpen, // "("
-    41: ImapWordType.parenClose, // ")"
-    91: ImapWordType.bracketOpen, // "["
-    93: ImapWordType.bracketClose, // "]"
+    10: ImapWordType.eol, // \n
+    43: ImapWordType.tokenPlus, // +
+    42: ImapWordType.tokenAsterisk, // *
+    40: ImapWordType.parenOpen, // (
+    41: ImapWordType.parenClose, // )
+    91: ImapWordType.bracketOpen, // [
+    93: ImapWordType.bracketClose, // ]
   };
 
   /// All characters considered whitespaces
   static const List<int> _whitespaceChars = const [
-    32, // " "
-    9, // "\t"
-    13 // "\r"
+    32, // " " (space)
+    9, // \t
+    13 // \r
   ];
 
   /// Adds data to the buffer
@@ -45,7 +45,7 @@ class ImapBuffer {
   Future<String> readLine({autoReleaseBuffer = true}) async {
     List<int> charCodes = <int>[];
     while (await _isWhitespace()) _bufferPosition++;
-    while (await _getCharCode() != 10) // "\n"
+    while (await _getCharCode() != 10) // \n
       charCodes.add(await _getCharCode(proceed: true));
     _bufferPosition++; // skip over newline character
     // trim trailing whitespaces
@@ -59,7 +59,7 @@ class ImapBuffer {
 
   /// Skips all characters in this line
   Future<void> skipLine({autoReleaseBuffer = true}) async {
-    while (await _getCharCode(proceed: true) != 10); // "skip until behind \n"
+    while (await _getCharCode(proceed: true) != 10); // skip until behind \n
     if (autoReleaseBuffer) _releaseUsedBuffer();
     return;
   }
@@ -76,11 +76,11 @@ class ImapBuffer {
     if (_specialChars.containsKey(charAtPosition))
       word = ImapWord(_specialChars[charAtPosition],
           String.fromCharCode(await _getCharCode(proceed: true)));
-    else if (charAtPosition == 34) // "\""
+    else if (charAtPosition == 34) // "
       word = await readQuotedString(autoReleaseBuffer: false);
-    else if (charAtPosition == 123) // "{"
+    else if (charAtPosition == 123) // {
       word = await readLiteral(autoReleaseBuffer: false);
-    else if (charAtPosition == 92) // "\\"
+    else if (charAtPosition == 92) // \
       word = await readFlag(autoReleaseBuffer: false);
     else
       word = await readAtom(autoReleaseBuffer: false);
@@ -93,30 +93,27 @@ class ImapBuffer {
 
   /// Reads a quoted string starting at the current [_bufferPosition]
   ///
-  /// Must start with "\""
+  /// Must start with "
   Future<ImapWord> readQuotedString({autoReleaseBuffer = true}) async {
     while (await _isWhitespace()) _bufferPosition++;
-    if (await _getCharCode() != 34) // "\""
+    if (await _getCharCode() != 34) // "
       throw new InvalidFormatException(
           "Expected quote at beginning of quoted string");
     _bufferPosition++;
     List<int> charCodes = <int>[];
     int nextChar = await _getCharCode(proceed: true);
-    while (nextChar != 34) {
-      // "\""
+    while (nextChar != 34 /* " */) {
       charCodes.add(nextChar);
       nextChar = await _getCharCode(proceed: true);
-      if (nextChar == 92) {
-        // "\\"
+      if (nextChar == 92 /* \ */) {
         nextChar = await _getCharCode(proceed: true); // skip first backslash
-        if (nextChar == 92 || nextChar == 34) {
-          // "\\" or "\""
+        if (nextChar == 92 /* \ */ || nextChar == 34 /* " */) {
           charCodes.add(nextChar);
           nextChar = await _getCharCode(proceed: true); // skip first backslash
         } else {
-          // bad format, only escape backslash or quotation mark
+          // bad format, only escaped backslash or quotation mark are supported
           throw new SyntaxErrorException(
-              "Unexpected escape sequence \\${String.fromCharCode(nextChar)}");
+              "Unknown escape sequence \\${String.fromCharCode(nextChar)}");
         }
       }
     }
@@ -126,10 +123,10 @@ class ImapBuffer {
 
   /// Reads a literal starting at the current [_bufferPosition]
   ///
-  /// Must start with "{"
+  /// Must start with {
   Future<ImapWord> readLiteral({autoReleaseBuffer = true}) async {
     while (await _isWhitespace()) _bufferPosition++;
-    if (await _getCharCode() != 123) // "{"
+    if (await _getCharCode() != 123) // {
       throw new InvalidFormatException(
           "Expected open curly bracket at beginning of literal");
     _bufferPosition++;
@@ -150,10 +147,10 @@ class ImapBuffer {
 
   /// Reads a flag starting at the current [_bufferPosition]
   ///
-  /// Must start with "\\"
+  /// Must start with \
   Future<ImapWord> readFlag({autoReleaseBuffer = true}) async {
     while (await _isWhitespace()) _bufferPosition++;
-    if (await _getCharCode() != 92) // "\\"
+    if (await _getCharCode() != 92) // \
       throw new InvalidFormatException("Expected \\ before flag name");
     _bufferPosition++;
     List<int> charCodes = <int>[92];
@@ -234,18 +231,16 @@ class ImapBuffer {
   Future<bool> _isValidAtomCharCode([int charCode = -1]) async {
     if (charCode == -1) charCode = await _getCharCode();
     if (charCode <= 31 || // CTL
-        charCode == 34 || // "\""
-        charCode == 37 || // "%"
-        charCode == 40 || // "("
-        charCode == 41 || // ")"
-        charCode == 42 || // "*"
-        charCode == 92 || // "\\"
-        charCode == 93 || // "]"
-        charCode == 123 || // "{"
-        charCode == 127) {
-      // CTL
-      return false;
-    }
+            charCode == 34 || // "
+            charCode == 37 || // %
+            charCode == 40 || // (
+            charCode == 41 || // )
+            charCode == 42 || // *
+            charCode == 92 || // \
+            charCode == 93 || // ]
+            charCode == 123 || // {
+            charCode == 127 // CTL
+        ) return false;
     return true;
   }
 

--- a/lib/src/imap_buffer.dart
+++ b/lib/src/imap_buffer.dart
@@ -114,8 +114,9 @@ class ImapBuffer {
           charCodes.add(nextChar);
           nextChar = await _getCharCode(proceed: true); // skip first backslash
         } else {
-          // probably an error, add raw char sequence
-          charCodes.add(92); // "\\"
+          // bad format, only escape backslash or quotation mark
+          throw new SyntaxErrorException(
+              "Unexpected escape sequence \\${String.fromCharCode(nextChar)}");
         }
       }
     }

--- a/lib/src/imap_buffer.dart
+++ b/lib/src/imap_buffer.dart
@@ -102,14 +102,17 @@ class ImapBuffer {
     _bufferPosition++;
     List<int> charCodes = <int>[];
     int nextChar = await _getCharCode(proceed: true);
-    while (nextChar != 34) {
+    while (nextChar != 34) { // "\""
       charCodes.add(nextChar);
       nextChar = await _getCharCode(proceed: true);
-      // escaped quotation mark "\\\""
-      if (nextChar == 92 && await _getCharCode() == 34) {}
-        // skip escaped quotation mark (only add one ", ignore backslash)
-        charCodes.add(await _getCharCode(proceed: true)); // add quotation mark
-        nextChar = await _getCharCode(proceed: true);
+      if (nextChar == 92 ) { // "\\"
+        nextChar = await _getCharCode(proceed: true); // skip first backslash
+        if (nextChar == 92 || nextChar == 34) { // "\\" or "\""
+          charCodes.add(nextChar);
+          nextChar = await _getCharCode(proceed: true); // skip first backslash
+        } else { // probably an error, add raw char sequence
+          charCodes.add(92); // "\\"
+        }
       }
     }
     if (autoReleaseBuffer) _releaseUsedBuffer();

--- a/lib/src/imap_buffer.dart
+++ b/lib/src/imap_buffer.dart
@@ -102,15 +102,19 @@ class ImapBuffer {
     _bufferPosition++;
     List<int> charCodes = <int>[];
     int nextChar = await _getCharCode(proceed: true);
-    while (nextChar != 34) { // "\""
+    while (nextChar != 34) {
+      // "\""
       charCodes.add(nextChar);
       nextChar = await _getCharCode(proceed: true);
-      if (nextChar == 92 ) { // "\\"
+      if (nextChar == 92) {
+        // "\\"
         nextChar = await _getCharCode(proceed: true); // skip first backslash
-        if (nextChar == 92 || nextChar == 34) { // "\\" or "\""
+        if (nextChar == 92 || nextChar == 34) {
+          // "\\" or "\""
           charCodes.add(nextChar);
           nextChar = await _getCharCode(proceed: true); // skip first backslash
-        } else { // probably an error, add raw char sequence
+        } else {
+          // probably an error, add raw char sequence
           charCodes.add(92); // "\\"
         }
       }

--- a/lib/src/imap_buffer.dart
+++ b/lib/src/imap_buffer.dart
@@ -101,9 +101,17 @@ class ImapBuffer {
           "Expected quote at beginning of quoted string");
     _bufferPosition++;
     List<int> charCodes = <int>[];
-    while (await _getCharCode() != 34) // "\""
-      charCodes.add(await _getCharCode(proceed: true));
-    _bufferPosition++; // move behind closing quote
+    int nextChar = await _getCharCode(proceed: true);
+    while (nextChar != 34) {
+      charCodes.add(nextChar);
+      nextChar = await _getCharCode(proceed: true);
+      // escaped quotation mark "\\\""
+      if (nextChar == 92 && await _getCharCode() == 34) {}
+        // skip escaped quotation mark (only add one ", ignore backslash)
+        charCodes.add(await _getCharCode(proceed: true)); // add quotation mark
+        nextChar = await _getCharCode(proceed: true);
+      }
+    }
     if (autoReleaseBuffer) _releaseUsedBuffer();
     return new ImapWord(ImapWordType.string, String.fromCharCodes(charCodes));
   }

--- a/test/imap_buffer_test.dart
+++ b/test/imap_buffer_test.dart
@@ -85,6 +85,23 @@ void main() {
       expect(await () async => await _buffer.readQuotedString(),
           throwsA(new TypeMatcher<InvalidFormatException>()));
     });
+    test('String may countain escaped quotation mark', () async {
+      var list = r'"A \"quotation mark\""'.codeUnits;
+      _controller.add(list);
+      expect((await _buffer.readQuotedString()).value, 'A "quotation mark"');
+    });
+    test('String may countain escaped backslash', () async {
+      var list = r'"A \\ backslash \\"'.codeUnits;
+      _controller.add(list);
+      expect((await _buffer.readQuotedString()).value, r'A \ backslash \');
+    });
+    test('Throws SyntaxErrorException if a characeter besides ", \\ is escaped',
+        () async {
+      var list = r'"A bad \format"'.codeUnits;
+      _controller.add(list);
+      expect(await () async => await _buffer.readQuotedString(),
+          throwsA(new TypeMatcher<SyntaxErrorException>()));
+    });
   });
 
   group("readLiteral tests", () {


### PR DESCRIPTION
Within quoted string quotation marks may appear as `...\"...`, which should not terminate the quote.
I observed this multiple times in fetch responses from gmail, leading to an error in the previous version.