### PR TITLE
Fix bug in readQuotedString: recognize leading escaped character

### DIFF
--- a/lib/src/imap_buffer.dart
+++ b/lib/src/imap_buffer.dart
@@ -103,19 +103,16 @@ class ImapBuffer {
     List<int> charCodes = <int>[];
     int nextChar = await _getCharCode(proceed: true);
     while (nextChar != 34 /* " */) {
-      charCodes.add(nextChar);
-      nextChar = await _getCharCode(proceed: true);
       if (nextChar == 92 /* \ */) {
         nextChar = await _getCharCode(proceed: true); // skip first backslash
-        if (nextChar == 92 /* \ */ || nextChar == 34 /* " */) {
-          charCodes.add(nextChar);
-          nextChar = await _getCharCode(proceed: true); // skip first backslash
-        } else {
+        if (nextChar != 34 /* " */ && nextChar != 92 /* \ */) {
           // bad format, only escaped backslash or quotation mark are supported
           throw new SyntaxErrorException(
               "Unknown escape sequence \\${String.fromCharCode(nextChar)}");
         }
       }
+      charCodes.add(nextChar);
+      nextChar = await _getCharCode(proceed: true);
     }
     if (autoReleaseBuffer) _releaseUsedBuffer();
     return new ImapWord(ImapWordType.string, String.fromCharCodes(charCodes));

--- a/test/imap_buffer_test.dart
+++ b/test/imap_buffer_test.dart
@@ -95,6 +95,11 @@ void main() {
       _controller.add(list);
       expect((await _buffer.readQuotedString()).value, r'A \ backslash \');
     });
+    test('String may start with escaped character', () async {
+      var list = r'"\"A quoted text\""'.codeUnits;
+      _controller.add(list);
+      expect((await _buffer.readQuotedString()).value, '"A quoted text"');
+    });
     test('Throws SyntaxErrorException if a characeter besides ", \\ is escaped',
         () async {
       var list = r'"A bad \format"'.codeUnits;


### PR DESCRIPTION
The implementation of readQuotedString only checks for a `\` after the first character (after the while check `nextChar != "`, the next character is immediately added). If the quoted string starts like `\"some text...`, this leads to unexpected behavior: the backslash is added and the subsequent `"` terminates the string. 

I have fixed this and added an appropriate test. The implementation should also be cleaner now.

My apologies for not getting this right in the first place; I must have been too tired when I first implemented this.